### PR TITLE
Revert "chore(deps): update lscr.io/linuxserver/homeassistant docker tag to v2023.2.1"

### DIFF
--- a/deployments/pathweb/home-assistant/kustomization.yaml
+++ b/deployments/pathweb/home-assistant/kustomization.yaml
@@ -6,7 +6,7 @@ commonLabels:
   app.kubernetes.io/name: home-assistant
 images:
 - name: lscr.io/linuxserver/homeassistant
-  newTag: "2023.2.1"
+  newTag: "2023.1.7"
 resources:
 - statefulset.yaml
 - service.yaml


### PR DESCRIPTION
Reverts ruifung/rfhome-infrastructure#33

Home assistant is crashlooping. 