### PR TITLE
Revert "Update Helm release external-dns to v7.3.3"

### DIFF
--- a/deployments/pathweb/external-dns/helm/helm.yaml
+++ b/deployments/pathweb/external-dns/helm/helm.yaml
@@ -18,7 +18,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 7.3.3
+      version: 7.3.2
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -69,7 +69,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 7.3.3
+      version: 7.3.2
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -127,7 +127,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 7.3.3
+      version: 7.3.2
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository

--- a/deployments/pi4-01/external-dns/helm.yaml
+++ b/deployments/pi4-01/external-dns/helm.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 7.3.3
+      version: 7.3.2
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -56,7 +56,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 7.3.3
+      version: 7.3.2
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -103,7 +103,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 7.3.3
+      version: 7.3.2
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
v7.3.3  helm chart is broken due to https://github.com/bitnami/charts/issues/25967

Reverts ruifung/rfhome-infrastructure#889